### PR TITLE
fix: miniGraphiQL component GET requests have undefined query and variables

### DIFF
--- a/components/MiniGraphiQL.jsx
+++ b/components/MiniGraphiQL.jsx
@@ -47,17 +47,22 @@ const MiniGraphiQLClient = ({ initialQuery, initialVariables, endpoint, readOnly
   const fetcher = createGraphiQLFetcher({
     url: endpoint,
     fetch: async (url, options) => {
-      // Construct query parameters
-      const params = new URLSearchParams({
-        query: options.body.query,
-        variables: JSON.stringify(options.body.variables),
-      });
+      const parsedBody = JSON.parse(options?.body);
+      
+      const params = new URLSearchParams();
+      params.append('query', parsedBody.query);
+      if (options.body.variables) {
+        params.append('variables', JSON.stringify(parsedBody.variables));
+      }
+      const getUrl = `${url}&${params.toString()}`;
 
       // Make the GET request
-      return fetch(`${url}?${params.toString()}`, { 
+      const res = await fetch(getUrl, { 
         method: 'GET', 
-        headers: { 'Accept': 'application/json' } 
+        headers: options?.headers,
       });
+
+      return res;
     }
   });
 


### PR DESCRIPTION
This PR updates the MiniGraphiQL fetcher to set the url and variables from the GraphiQL Component and pass it as queryParams to the GET request. 

closes #39 

## BEFORE

![CleanShot 2023-12-20 at 13 08 25](https://github.com/wp-graphql/acf.wpgraphql.com/assets/1260765/40107dda-d1b1-44a3-9650-7914a6903a27)


## AFTER
![CleanShot 2023-12-20 at 13 08 05](https://github.com/wp-graphql/acf.wpgraphql.com/assets/1260765/ac8c2c13-11b0-45ab-b40f-0f78b66436c5)
