### PR TITLE
chore: minor style adjustments

### DIFF
--- a/components/Layout.jsx
+++ b/components/Layout.jsx
@@ -133,7 +133,7 @@ export function Layout({ data, children, toc, title }) {
       <main className='content'>
         <div className="relative mx-auto flex max-w-8xl justify-center sm:px-2 lg:px-8 xl:px-12">
           <div className="hidden lg:relative lg:block lg:flex-none">
-            <div className="absolute inset-y-0 right-0 w-[50vw] bg-slate-50 dark:hidden" />
+            <div className="absolute inset-y-0 right-0 w-[50vw] bg-slate-50 dark:bg-gray-800/25" />
             <div className="absolute bottom-0 right-0 top-16 hidden h-12 w-px bg-gradient-to-t from-slate-800 dark:block" />
             <div className="absolute bottom-0 right-0 top-28 hidden w-px bg-slate-800 dark:block" />
             <div className="sticky top-[4.5rem] -ml-0.5 h-[calc(100vh-4.5rem)] w-64 overflow-y-auto overflow-x-hidden py-16 pl-0.5 pr-8 xl:w-72 xl:pr-16">

--- a/components/SiteHeader.jsx
+++ b/components/SiteHeader.jsx
@@ -34,7 +34,7 @@ export function SiteHeader({ navigation, isNoticeVisible = false }) {
         'z-40 flex flex-wrap items-center justify-between bg-white px-4 py-5 shadow-md shadow-slate-900/5 transition duration-500 dark:shadow-none sm:px-6 lg:px-8',
         isScrolled
           ? 'dark:bg-slate-900/95 dark:backdrop-blur dark:[@supports(backdrop-filter:blur(0))]:bg-slate-900/75'
-          : 'dark:bg-transparent',
+          : 'dark:bg-slate-900',
       )}
     >
       <div className="mr-6 flex lg:hidden">


### PR DESCRIPTION
In light mode, the sidebar nav on the left has a slightly different BG color than the body where the majority of the page content is: 

![CleanShot 2024-01-09 at 16 59 27](https://github.com/wp-graphql/acf.wpgraphql.com/assets/1260765/1d6c89b1-195c-44c4-a54f-29e4ecc4a989)

This PR updates some styles so Dark Mode has a similar contrast between the left nav and the body:

## BEFORE

![CleanShot 2024-01-09 at 16 58 06](https://github.com/wp-graphql/acf.wpgraphql.com/assets/1260765/2ccd7be4-77c0-458c-ba09-ab18bda89697)


## AFTER

![CleanShot 2024-01-09 at 16 57 48](https://github.com/wp-graphql/acf.wpgraphql.com/assets/1260765/d6940576-fca5-41f1-af0f-4e5454d1d63f)
