### PR TITLE
fix: fallback if acfFieldType is not there

### DIFF
--- a/wp-blocks/AcfFieldTypeConfigurationBlock.js
+++ b/wp-blocks/AcfFieldTypeConfigurationBlock.js
@@ -53,9 +53,7 @@ function generateJSONTabContent(data) {
 
 function TabContent({ fieldTypeConfigurationBlockFields, uniqueId, format }) {
   const { acfFieldType } = fieldTypeConfigurationBlockFields;
-  if ( ! acfFieldType ) {
-    return null;
-  };
+  
   const data = generateData(uniqueId, acfFieldType);
 
   return format === 'php' ? generatePHPTabContent(data) : generateJSONTabContent(data);
@@ -64,7 +62,13 @@ function TabContent({ fieldTypeConfigurationBlockFields, uniqueId, format }) {
 export function AcfFieldTypeConfigurationBlock({ fieldTypeConfigurationBlockFields }) {
   const { acfFieldType } = fieldTypeConfigurationBlockFields;
   if ( ! acfFieldType ) {
-    return null;
+    return (
+      <Card>
+        <CardHeader className="grid grid-cols-[1fr_110px] items-start space-y-2">
+          Field Type Config has not been configured for this field type
+        </CardHeader>
+      </Card>
+    );
   };
   const [uniqueId, setUniqueId] = useState('');
 


### PR DESCRIPTION
We're getting errors when the `AcfFieldTypeConfigurationBlock` doesn't have an `acfFieldType` value returned.

### BEFORE

![CleanShot 2024-01-10 at 17 19 16](https://github.com/wp-graphql/acf.wpgraphql.com/assets/1260765/4da1285f-0fee-4085-b776-abdc05c77b4f)

### AFTER

![CleanShot 2024-01-10 at 17 21 44](https://github.com/wp-graphql/acf.wpgraphql.com/assets/1260765/55fada7c-734f-4ffd-b0fd-942c10fb690e)
