### PR TITLE
feat: sort the settings alphabetically

### DIFF
--- a/wp-blocks/AcfFieldTypeSettingsBlock.js
+++ b/wp-blocks/AcfFieldTypeSettingsBlock.js
@@ -58,12 +58,28 @@ export function AcfFieldTypeSettingsBlock({ fieldTypeSettingsBlockFields }) {
     );
   }
 
+  // copy the nodes so we can sort them before returning
+  const settings = [...fieldTypeSettings?.nodes];
+
+  // sort by name
+  settings.sort((a, b) => {
+    let nameA = a.name.toUpperCase(); // ignore upper and lowercase
+    let nameB = b.name.toUpperCase(); // ignore upper and lowercase
+    if (nameA < nameB) {
+      return -1; //nameA comes first
+    }
+    if (nameA > nameB) {
+      return 1; // nameB comes first
+    }
+    return 0;  // names must be equal
+  });
+
   return (
     <>
     <p>Below you will find information about how various ACF field settings can impact how the field will map to the GraphQL Schema and/or modify resolution of the field when queried.</p>
       <Card>
         <CardHeader className="grid grid-cols-[1fr_110px] items-start space-y-2">
-          {fieldTypeSettings?.nodes?.map((item, index) => {
+          {settings?.map((item, index) => {
             const { id, name, description, fieldTypeSettingsMeta } = item;
             const { impactOnWpgraphql, acfFieldName } = fieldTypeSettingsMeta;
 


### PR DESCRIPTION
This sorts the field settings before rendering. 

This should make it easier for users to parse the docs as they consume the information.

### Before


![CleanShot 2024-01-10 at 18 02 38](https://github.com/wp-graphql/acf.wpgraphql.com/assets/1260765/40aa6bc1-7c92-4e38-b88d-1a1b10f3e4af)

### After

![CleanShot 2024-01-10 at 18 03 14](https://github.com/wp-graphql/acf.wpgraphql.com/assets/1260765/03916d57-cf7d-4899-8089-d77fc0f854a9)
