### PR TITLE
fix: keep field type menu expanded when field type template is being viewed

### DIFF
--- a/wp-blocks/index.js
+++ b/wp-blocks/index.js
@@ -1,4 +1,5 @@
 import { CoreBlocks } from '@faustwp/blocks'
+
 import { AcfFieldTypeConfigurationBlock } from './AcfFieldTypeConfigurationBlock'
 import { AcfFieldTypeSettingsBlock } from './AcfFieldTypeSettingsBlock'
 import { AcfGraphqlQuery } from './AcfGraphqlQuery'

--- a/wp-templates/front-page.js
+++ b/wp-templates/front-page.js
@@ -1,11 +1,11 @@
 import { gql } from '@apollo/client'
+import { useFaustQuery } from '@faustwp/core'
 
 import HomepageLayoutsLayoutsFaqsLayout from '@/components/HomepageLayoutsLayoutsFaqsLayout'
 import HomepageLayoutsLayoutsFeaturesLayout from '@/components/HomepageLayoutsLayoutsFeaturesLayout'
 import HomepageLayoutsLayoutsHeroLayout from '@/components/HomepageLayoutsLayoutsHeroLayout'
 import HomepageLayoutsLayoutsSupportedFieldTypesLayout from '@/components/HomepageLayoutsLayoutsSupportedFieldTypesLayout'
 import { LayoutFrontPage, LAYOUT_FRONT_PAGE_QUERY } from '@/components/LayoutFrontPage'
-import { useFaustQuery } from '@faustwp/core'
 
 const FRONT_PAGE_QUERY = gql`
   query GetFrontPage($uri: String!) {

--- a/wp-templates/single-field_type.js
+++ b/wp-templates/single-field_type.js
@@ -113,7 +113,7 @@ export const SingleFieldType = () => {
       <Head>
         <title>{`${title} - WPGraphQL for ACF`}</title>
       </Head>
-      <Layout toc={toc}>
+      <Layout node={node} toc={toc}>
         <h1>{title}</h1>
         {node?.aCFFieldTypeCategories && node?.aCFFieldTypeCategories?.nodes && (
           <div id="field-type-categories" className="my-2">


### PR DESCRIPTION
This fixes a bug where the "Field Type" menu on the left side wasn't properly in an expanded state when viewing content on a single-field_type template. 